### PR TITLE
Correction about starting Built-in PHP Server

### DIFF
--- a/doc/book/getting-started/skeleton-application.md
+++ b/doc/book/getting-started/skeleton-application.md
@@ -227,7 +227,7 @@ You can use PHP's built-in web server when developing your application. To do
 this, start the server from the project's root directory:
 
 ```bash
-$ php -S 0.0.0.0:8080 -t public/ public/index.php
+$ php -S 0.0.0.0:8080 -t public public/index.php
 ```
 
 This will make the website available on port 8080 on all network interfaces,


### PR DESCRIPTION
When I run the following command into my bash:
`php -S 0.0.0.0:8080 -t public/ public/index.php`

I get the following error message:
`bash: $: command not found`

And when running the "composer serve" the message goes to:
```
Directory public/ does not exist.
Script php -S 0.0.0.0:8080 -t public/ public/index.php handling the serve event returned with error code 1
```

I'm using Windows (7 version) with xampp. 

I tried some stuffs but simply the remotion of "/" makes the service start the web server, that's why I made this adjust in the documentation, works in Linux / Windows here. 

I was caught in testing "\\", "\", "/"... and nothing, only working without it...